### PR TITLE
Runnables, injections and minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ To use nph as a formatter, add this to your settings
 ```
 
 ## To-Do List for Project:
-- Fix Project Config options
-- Add runnable functionality
-- Implement Debug Task
-- Develop Macros
-- Create code snippets
+- [ ] Fix Project Config options
+- [x] Add runnable functionality
+- [ ] Implement Debug Task
+- [ ] Develop Macros
+- [ ] Create code snippets

--- a/extension.toml
+++ b/extension.toml
@@ -13,3 +13,7 @@ language = "Nim"
 [grammars.nim]
 repository = "https://github.com/alaviss/tree-sitter-nim"
 commit = "897e5d346f0b59ed62b517cfb0f1a845ad8f0ab7"
+
+[grammars.nim_format_string]
+repository = "https://github.com/aMOPel/tree-sitter-nim-format-string"
+commit = "d45f75022d147cda056e98bfba68222c9c8eca3a"

--- a/languages/nim/brackets.scm
+++ b/languages/nim/brackets.scm
@@ -1,4 +1,5 @@
 ("(" @open ")" @close)
 ("[" @open "]" @close)
 ("{" @open "}" @close)
+("{." @open ".}" @close)
 ("#[" @open "]#" @close)

--- a/languages/nim/config.toml
+++ b/languages/nim/config.toml
@@ -1,11 +1,12 @@
 name = "Nim"
 code_fence_block_name = "nim"
 grammar = "nim"
-path_suffixes = ["nim"]
+path_suffixes = ["nim", "nims"]
 autoclose_before = ";:.,=}])>"
 
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
+    { start = "{.", end = ".", close = true, newline = true, not_in = ["string", "comment"] },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },

--- a/languages/nim/injections.scm
+++ b/languages/nim/injections.scm
@@ -4,16 +4,16 @@
 (generalized_string
   function: (identifier) @_string_prefix
   .
-  (string_content) @injection.content
-  (#set! injection.language "regex")
+  (string_content) @content
+  (#set! "language" "regex")
   (#any-of? @_string_prefix "re" "rex"))
 
 ; format string in generalized_strings
 (generalized_string
   function: (identifier) @_string_prefix
   .
-  (string_content) @injection.content
-  (#set! injection.language "nim_format_string")
+  (string_content) @content
+  (#set! "language" "nim_format_string")
   (#eq? @_string_prefix "fmt"))
 
 ; format string in normal strings with & prefix
@@ -21,16 +21,61 @@
   operator: (operator) @_string_prefix
   .
   (_
-    (string_content) @injection.content)
-  (#set! injection.language "nim_format_string")
+    (string_content) @content)
+  (#set! "language" "nim_format_string")
   (#eq? @_string_prefix "&"))
 
 ; sql in generalized_strings
 ; and anything you like as long as the function name is the same as the injected language's parser
+
+; TODO: this doesn't work dynamically, must be a workaround
+; (generalized_string
+;   function: (identifier) @injection.language
+;   (string_content) @content
+;   (#not-any-of? @injection.language "re" "rex" "fmt"))
+
+; SQL, HTML, CSS, XML, GLSL and Markdown
 (generalized_string
-  function: (identifier) @injection.language
-  (string_content) @injection.content
-  (#not-any-of? @injection.language "re" "rex" "fmt"))
+  function: (identifier) @_string_prefix
+  .
+  (string_content) @content
+  (#set! "language" "sql")
+  (#eq? @_string_prefix "sql"))
+
+(generalized_string
+  function: (identifier) @_string_prefix
+  .
+  (string_content) @content
+  (#set! "language" "html")
+  (#eq? @_string_prefix "html"))
+
+(generalized_string
+  function: (identifier) @_string_prefix
+  .
+  (string_content) @content
+  (#set! "language" "css")
+  (#eq? @_string_prefix "css"))
+
+(generalized_string
+  function: (identifier) @_string_prefix
+  .
+  (string_content) @content
+  (#set! "language" "xml")
+  (#eq? @_string_prefix "xml"))
+
+(generalized_string
+  function: (identifier) @_string_prefix
+  .
+  (string_content) @content
+  (#set! "language" "glsl")
+  (#eq? @_string_prefix "glsl"))
+
+(generalized_string
+  function: (identifier) @_string_prefix
+  .
+  (string_content) @content
+  (#set! "language" "markdown")
+  (#eq? @_string_prefix "md"))
 
 ; =============================================================================
 ; emit pragma
@@ -45,7 +90,8 @@
 ; {.emit: "<javascript code>".}
 ; normal strings
 ((comment
-  (comment_content) @injection.language)
+  (comment_content) @_language
+  (#eq? @_language "cpp"))
   .
   (pragma_statement
     (pragma_list
@@ -53,27 +99,65 @@
         left: (identifier) @_emit_keyword
         (#eq? @_emit_keyword "emit")
         right: (_
-          (string_content) @injection.content)))))
+          (string_content) @content))))
+  (#set! "language" "cpp"))
+
+((comment
+  (comment_content) @_language
+  (#eq? @_language "c"))
+  .
+  (pragma_statement
+    (pragma_list
+      (colon_expression
+        left: (identifier) @_emit_keyword
+        (#eq? @_emit_keyword "emit")
+        right: (_
+          (string_content) @content))))
+  (#set! "language" "c"))
+
+((comment
+  (comment_content) @_language
+  (#eq? @_language "objc"))
+  .
+  (pragma_statement
+    (pragma_list
+      (colon_expression
+        left: (identifier) @_emit_keyword
+        (#eq? @_emit_keyword "emit")
+        right: (_
+          (string_content) @content))))
+  (#set! "language" "objc"))
+
+((comment
+  (comment_content) @_language
+  (#eq? @_language "javascript"))
+  .
+  (pragma_statement
+    (pragma_list
+      (colon_expression
+        left: (identifier) @_emit_keyword
+        (#eq? @_emit_keyword "emit")
+        right: (_
+          (string_content) @content))))
+  (#set! "language" "javascript"))
+
 
 ; =============================================================================
 ; asm statement
-; works same as emit pragma, needs preceding comment with language name
-((comment
-  (comment_content) @injection.language)
-  .
-  (assembly_statement
+((assembly_statement
     (_
-      (string_content) @injection.content)))
+      (string_content) @content))
+  (#set! "language" "asm"))
 
 ; =============================================================================
 ; comments
 ; NOTE: ts "comment" parser heavily impacts performance
 ; markdown parser in documentation_comment
 (documentation_comment
-  (comment_content) @injection.content
-  (#set! injection.language "markdown_inline"))
+  (comment_content) @content
+  (#set! "language" "markdown_inline"))
 
 ; markdown parser in block_documentation_comment
 (block_documentation_comment
-  (comment_content) @injection.content
-  (#set! injection.language "markdown"))
+  (comment_content) @content
+  (#set! "language" "markdown"))

--- a/languages/nim/injections.scm
+++ b/languages/nim/injections.scm
@@ -28,47 +28,10 @@
 ; sql in generalized_strings
 ; and anything you like as long as the function name is the same as the injected language's parser
 
-; TODO: this doesn't work dynamically, must be a workaround
-; (generalized_string
-;   function: (identifier) @injection.language
-;   (string_content) @content
-;   (#not-any-of? @injection.language "re" "rex" "fmt"))
-
-; SQL, HTML, CSS, XML, GLSL and Markdown
 (generalized_string
-  function: (identifier) @_string_prefix
-  .
+  function: (identifier) @language
   (string_content) @content
-  (#set! "language" "sql")
-  (#eq? @_string_prefix "sql"))
-
-(generalized_string
-  function: (identifier) @_string_prefix
-  .
-  (string_content) @content
-  (#set! "language" "html")
-  (#eq? @_string_prefix "html"))
-
-(generalized_string
-  function: (identifier) @_string_prefix
-  .
-  (string_content) @content
-  (#set! "language" "css")
-  (#eq? @_string_prefix "css"))
-
-(generalized_string
-  function: (identifier) @_string_prefix
-  .
-  (string_content) @content
-  (#set! "language" "xml")
-  (#eq? @_string_prefix "xml"))
-
-(generalized_string
-  function: (identifier) @_string_prefix
-  .
-  (string_content) @content
-  (#set! "language" "glsl")
-  (#eq? @_string_prefix "glsl"))
+  (#not-any-of? @language "re" "rex" "fmt" "md"))
 
 (generalized_string
   function: (identifier) @_string_prefix
@@ -90,8 +53,7 @@
 ; {.emit: "<javascript code>".}
 ; normal strings
 ((comment
-  (comment_content) @_language
-  (#eq? @_language "cpp"))
+  (comment_content) @language)
   .
   (pragma_statement
     (pragma_list
@@ -99,47 +61,7 @@
         left: (identifier) @_emit_keyword
         (#eq? @_emit_keyword "emit")
         right: (_
-          (string_content) @content))))
-  (#set! "language" "cpp"))
-
-((comment
-  (comment_content) @_language
-  (#eq? @_language "c"))
-  .
-  (pragma_statement
-    (pragma_list
-      (colon_expression
-        left: (identifier) @_emit_keyword
-        (#eq? @_emit_keyword "emit")
-        right: (_
-          (string_content) @content))))
-  (#set! "language" "c"))
-
-((comment
-  (comment_content) @_language
-  (#eq? @_language "objc"))
-  .
-  (pragma_statement
-    (pragma_list
-      (colon_expression
-        left: (identifier) @_emit_keyword
-        (#eq? @_emit_keyword "emit")
-        right: (_
-          (string_content) @content))))
-  (#set! "language" "objc"))
-
-((comment
-  (comment_content) @_language
-  (#eq? @_language "javascript"))
-  .
-  (pragma_statement
-    (pragma_list
-      (colon_expression
-        left: (identifier) @_emit_keyword
-        (#eq? @_emit_keyword "emit")
-        right: (_
-          (string_content) @content))))
-  (#set! "language" "javascript"))
+          (string_content) @content)))))
 
 
 ; =============================================================================

--- a/languages/nim/runnables.scm
+++ b/languages/nim/runnables.scm
@@ -1,0 +1,58 @@
+; runnable main module
+((when
+    condition: (identifier) @run (#eq? @run "isMainModule"))
+    (#set! tag nim-main))
+
+((when
+    condition: (parenthesized ((identifier) @run (#eq? @run "isMainModule")) ))
+    (#set! tag nim-main))
+
+; runnable tests
+; suite
+((call
+    function: (identifier) @run (#eq? @run "suite")
+    (argument_list
+        ((interpreted_string_literal
+               . (string_content) @nim_suite)
+        )
+        ":"
+    )) @_nim-unittest
+  (#set! tag nim-unittest))
+
+; single test
+(source_file ((call
+    function: (identifier) @run (#eq? @run "test")
+    (argument_list
+        ((interpreted_string_literal
+               . (string_content) @nim_test)
+        )
+        ":"
+    )) @_nim-unittest
+  (#set! tag nim-unittest-single)))
+
+; test in the suite
+(
+  (call
+    function: (identifier) @_suite_name (#eq? @_suite_name "suite")
+    (argument_list
+      ((interpreted_string_literal
+         . (string_content) @nim_suite)
+      )
+      ":"
+      ; .
+      (statement_list
+        (_)?
+        (call
+          function: (identifier) @run (#eq? @run "test")
+          (argument_list
+            ((interpreted_string_literal
+               . (string_content) @nim_test)
+            )
+            ":"
+          )
+        )
+      )
+    )
+  ) @_nim-unittest
+  (#set! tag nim-unittest-suite)
+)

--- a/languages/nim/tasks.json
+++ b/languages/nim/tasks.json
@@ -4,7 +4,8 @@
     "command": "nim",
     "args": ["c", "-r", "$ZED_FILE"],
     "use_new_terminal": false,
-    "reveal": "always"
+    "reveal": "always",
+    "tags": ["nim-main"]
   },
     {
     "label": "Nimble Run",
@@ -26,5 +27,29 @@
     "args": ["test"],
     "use_new_terminal": false,
     "reveal": "always"
+  },
+  {
+    "label": "Unittest suite",
+    "command": "nim",
+    "args": ["c", "-r", "$ZED_FILE", "\"$ZED_CUSTOM_nim_suite::\""],
+    "use_new_terminal": false,
+    "reveal": "always",
+    "tags": ["nim-unittest"]
+  },
+  {
+    "label": "Unittest single test",
+    "command": "nim",
+    "args": ["c", "-r", "$ZED_FILE", "\"$ZED_CUSTOM_nim_test\""],
+    "use_new_terminal": false,
+    "reveal": "always",
+    "tags": ["nim-unittest-single"]
+  },
+  {
+    "label": "Unittest test in suite",
+    "command": "nim",
+    "args": ["c", "-r", "$ZED_FILE", "\"$ZED_CUSTOM_nim_suite::$ZED_CUSTOM_nim_test\""],
+    "use_new_terminal": false,
+    "reveal": "always",
+    "tags": ["nim-unittest-suite"]
   }
 ]

--- a/languages/nim_format_string/config.toml
+++ b/languages/nim_format_string/config.toml
@@ -1,0 +1,3 @@
+name = "Nim Format String"
+grammar = "nim_format_string"
+path_suffixes = ["nim_format_string"]

--- a/languages/nim_format_string/highlights.scm
+++ b/languages/nim_format_string/highlights.scm
@@ -1,0 +1,20 @@
+(string_literal) @string
+(matching_curlies
+  opening_curly: (opening_curly) @punctuation.special
+  equals: (equals)? @punctuation.special
+  closing_curly: (closing_curly) @punctuation.special)
+
+(format_specifiers
+  colon: (colon) @punctuation.delimiter
+  fill_align: (fill_align)? @conditional.ternary
+  sign: (sign)? @operator
+  hash: (hash)? @punctuation.special
+  zero: (zero)? @field
+  min_width: (min_width)? @constant
+  precision: (precision)? @constant
+  type: (type)? @type)
+
+(matching_curlies
+  nim_expression: (nim_expression
+    escaped_curly: (escaped_curly)+ @string.escape)
+)

--- a/languages/nim_format_string/injections.scm
+++ b/languages/nim_format_string/injections.scm
@@ -1,0 +1,1 @@
+((matching_curlies (nim_expression) @content) (#set! "language" "nim"))


### PR DESCRIPTION
##### Foreword
<sup>Things should probably be better tested. I have noticed some bugs occur at random times, but could not reproduce them, and it could've been on the side of Zed itself too.</sup>

## Runnables
Added support for play button in: 
1. `when isMainModule:` sections
2. `suite` and `test` macros for unit tests

Unit test runnables support running suites, separate single tests and single test within suites. Works with default `unittest` and [unittest2](https://github.com/status-im/nim-unittest2.git) modules.

<img width="676" alt="0" src="https://github.com/user-attachments/assets/cc5d4484-a082-4ee6-b475-c53dcab35cb5">

## Injections
Fixed language name capture for emits and Assembly, added Markdown injection for `md"..."` generalized strings.

| Before | After |
| ---- | ---- |
| <img width="567" alt="2" src="https://github.com/user-attachments/assets/419f6cae-7301-4a82-b192-d839ba8e7c7b"> | <img width="567" alt="1" src="https://github.com/user-attachments/assets/e7f52fe3-1b22-4135-8355-49a71611ec11"> |

**Note**:
Zed should have a corresponding language extension installed for syntax highlighting to work: [SQL](https://github.com/nervenes/zed-sql.git), [Assembly](https://github.com/DevBlocky/zed-asm.git), [GLSL](https://github.com/zed-industries/zed/tree/773a3b335edc1cd686d06cf1e3a259f359a21d2c/extensions/glsl) and others. 
As of now (02.11.2024), there is no language extensions for Objective-C, hence there is no syntax highlighting for it. If such extension appears, it in theory should work as-is (if it has `objc` language ID).

## Other stuff
- Added `.nims` file extension for NimScript files.
- Added auto-close and bracket handling for pragmas (probably not in the best way, but it works)
![3](https://github.com/user-attachments/assets/3072d367-beb4-4ec2-ba50-25d3365a1d43)

Edit:
Resolves #3.
<img width="329" alt="Screenshot 2024-11-03 at 00 41 24" src="https://github.com/user-attachments/assets/d9dd0199-a159-4979-9bd6-a7caad605f83">

